### PR TITLE
Fixed filtering empty input parameters

### DIFF
--- a/lib/FSi/Component/DataSource/Driver/Collection/CollectionAbstractField.php
+++ b/lib/FSi/Component/DataSource/Driver/Collection/CollectionAbstractField.php
@@ -44,7 +44,7 @@ abstract class CollectionAbstractField extends FieldAbstractType implements Coll
     {
         $data = $this->getCleanParameter();
 
-        if (empty($data) && ($data !== 0) && ($data !== false)) {
+        if (($data === array()) || ($data === '') || ($data === null)) {
             return;
         }
 

--- a/lib/FSi/Component/DataSource/Driver/Doctrine/ORM/DoctrineAbstractField.php
+++ b/lib/FSi/Component/DataSource/Driver/Doctrine/ORM/DoctrineAbstractField.php
@@ -27,7 +27,7 @@ abstract class DoctrineAbstractField extends FieldAbstractType implements Doctri
         $fieldName = $this->getFieldName($alias);
         $name = $this->getName();
 
-        if (empty($data) && ($data !== 0) && ($data !== false)) {
+        if (($data === array()) || ($data === '') || ($data === null)) {
             return;
         }
 

--- a/tests/FSi/Component/DataSource/Tests/Driver/Collection/CollectionDriverTest.php
+++ b/tests/FSi/Component/DataSource/Tests/Driver/Collection/CollectionDriverTest.php
@@ -60,6 +60,32 @@ class CollectionDriverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test number field when comparing with 0 value.
+     */
+    public function testComparingWithZero()
+    {
+        $datasourceFactory = $this->getDataSourceFactory();
+        $driverOptions = array(
+            'collection' => $this->em->getRepository('FSi\Component\DataSource\Tests\Fixtures\News')->findAll(),
+        );
+
+        $datasource = $datasourceFactory
+            ->createDataSource('collection', $driverOptions, 'datasource')
+            ->addField('id', 'number', 'eq');
+
+        $parameters = array(
+            $datasource->getName() => array(
+                DataSourceInterface::PARAMETER_FIELDS => array(
+                    'id' => '0',
+                ),
+            ),
+        );
+        $datasource->bindParameters($parameters);
+        $result = $datasource->getResult();
+        $this->assertEquals(0, count($result));
+    }
+
+    /**
      * General test for DataSource wtih DoctrineDriver in basic configuration.
      */
     public function testGeneral()

--- a/tests/FSi/Component/DataSource/Tests/Driver/Doctrine/ORM/DoctrineDriverBasicTest.php
+++ b/tests/FSi/Component/DataSource/Tests/Driver/Doctrine/ORM/DoctrineDriverBasicTest.php
@@ -244,10 +244,6 @@ class DoctrineDriverBasicTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($driver->hasFieldType($type));
         $field = $driver->getFieldType($type);
         $this->assertTrue($field instanceof \FSi\Component\DataSource\Field\FieldTypeInterface);
-        if (!$field instanceof \FSi\Component\DataSource\Driver\Doctrine\ORM\DoctrineFieldInterface){
-            var_dump($field);
-            die();
-        }
         $this->assertTrue($field instanceof \FSi\Component\DataSource\Driver\Doctrine\ORM\DoctrineFieldInterface);
 
         $this->assertTrue($field->getOptionsResolver()->isKnown('field'));

--- a/tests/FSi/Component/DataSource/Tests/Driver/Doctrine/ORM/DoctrineDriverTest.php
+++ b/tests/FSi/Component/DataSource/Tests/Driver/Doctrine/ORM/DoctrineDriverTest.php
@@ -66,6 +66,32 @@ class DoctrineDriverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test number field when comparing with 0 value.
+     */
+    public function testComparingWithZero()
+    {
+        $datasourceFactory = $this->getDataSourceFactory();
+        $driverOptions = array(
+            'entity' => 'FSi\Component\DataSource\Tests\Fixtures\News',
+        );
+
+        $datasource = $datasourceFactory
+            ->createDataSource('doctrine-orm', $driverOptions, 'datasource')
+            ->addField('id', 'number', 'eq');
+
+        $parameters = array(
+            $datasource->getName() => array(
+                DataSourceInterface::PARAMETER_FIELDS => array(
+                    'id' => '0',
+                ),
+            ),
+        );
+        $datasource->bindParameters($parameters);
+        $result = $datasource->getResult();
+        $this->assertEquals(0, count($result));
+    }
+
+    /**
      * General test for DataSource wtih DoctrineDriver in basic configuration.
      */
     public function testGeneral()

--- a/tests/FSi/Component/DataSource/Tests/Driver/Doctrine/ORM/DoctrineResultTest.php
+++ b/tests/FSi/Component/DataSource/Tests/Driver/Doctrine/ORM/DoctrineResultTest.php
@@ -9,7 +9,7 @@
 
 namespace FSi\Component\DataSource\Tests\Driver\Doctrine\ORM;
 
-use FSi\Component\DataSource\Driver\Doctrine\DoctrineResult;
+use FSi\Component\DataSource\Driver\Doctrine\ORM\DoctrineResult;
 
 class DoctrineResultTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
This change seems to be radical but in fact the new condition differs from the old one because it does not return `true` for neither `'0'` nor `0.0` as the old one did. In all other cases it behaves exactly the same way. This fixes #38 
