### PR TITLE
Add support for composite keys with Paginator

### DIFF
--- a/lib/Driver/Doctrine/ORM/DoctrineDriver.php
+++ b/lib/Driver/Doctrine/ORM/DoctrineDriver.php
@@ -10,9 +10,7 @@
 namespace FSi\Component\DataSource\Driver\Doctrine\ORM;
 
 use FSi\Component\DataSource\Driver\DriverAbstract;
-use FSi\Component\DataSource\Driver\Doctrine\ORM\DoctrineFieldInterface;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Tools\Pagination\Paginator;
 use FSi\Component\DataSource\Driver\Doctrine\ORM\Exception\DoctrineDriverException;
 use Doctrine\ORM\QueryBuilder;
 

--- a/lib/Driver/Doctrine/ORM/DoctrineResult.php
+++ b/lib/Driver/Doctrine/ORM/DoctrineResult.php
@@ -11,7 +11,7 @@ namespace FSi\Component\DataSource\Driver\Doctrine\ORM;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\ORM\Tools\Pagination\Paginator;
+use Doctrine\ORM\Tools\Pagination\Paginator as DoctrinePaginator;
 use FSi\Component\DataIndexer\DoctrineDataIndexer;
 
 class DoctrineResult extends ArrayCollection
@@ -25,7 +25,7 @@ class DoctrineResult extends ArrayCollection
      * @param \Doctrine\Common\Persistence\ManagerRegistry $registry
      * @param \Doctrine\ORM\Tools\Pagination\Paginator $paginator
      */
-    public function __construct(ManagerRegistry $registry, Paginator $paginator)
+    public function __construct(ManagerRegistry $registry, DoctrinePaginator $paginator)
     {
         $result = array();
         $this->count = $paginator->count();

--- a/lib/Driver/Doctrine/ORM/Paginator.php
+++ b/lib/Driver/Doctrine/ORM/Paginator.php
@@ -1,0 +1,22 @@
+<?php
+namespace FSi\Component\DataSource\Driver\Doctrine\ORM;
+
+use Doctrine\ORM\Tools\Pagination\Paginator as DoctrinePaginator;
+
+class Paginator extends DoctrinePaginator
+{
+    public function __construct($query, $fetchJoinCollection = true)
+    {
+        // Avoid DDC-2213 bug/mistake
+        $em = $query->getEntityManager();
+        $fetchJoinCollection = true;
+        foreach ($query->getRootEntities() as $entity) {
+            if ($em->getClassMetadata($entity)->isIdentifierComposite) {
+                $fetchJoinCollection = false;
+                break;
+            }
+        }
+
+        parent::__construct($query, $fetchJoinCollection);
+    }
+}


### PR DESCRIPTION
Paginator supports composite keys only when fetchJoinCollection is false.
This PR will check if fetchJoinCollection needs to be false.

Also see http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/pagination.html and http://www.doctrine-project.org/jira/browse/DDC-2213