### PR TITLE
Renamed 'nin' comparison to 'notIn' in CollectionDriver

### DIFF
--- a/lib/Driver/Collection/CollectionAbstractField.php
+++ b/lib/Driver/Collection/CollectionAbstractField.php
@@ -87,8 +87,12 @@ abstract class CollectionAbstractField extends FieldAbstractType implements Coll
             }
         }
 
-        if (in_array($comparison, array('in', 'nin')) && !is_array($data)) {
-            throw new CollectionDriverException('Fields with \'in\' and \'nin\' comparisons require to bind an array.');
+        if ($comparison === 'nin') {
+            $comparison = 'notIn';
+        }
+
+        if (in_array($comparison, array('in', 'nin', 'notIn')) && !is_array($data)) {
+            throw new CollectionDriverException('Fields with \'in\' and \'notIn\' comparisons require to bind an array.');
         }
 
         if (isset($type)) {

--- a/lib/Driver/Collection/Extension/Core/Field/Text.php
+++ b/lib/Driver/Collection/Extension/Core/Field/Text.php
@@ -18,8 +18,10 @@ class Text extends CollectionAbstractField
 {
     /**
      * {@inheritdoc}
+     *
+     * 'nin' comparison is deprecated since 1.3 and will be removed in 2.0
      */
-    protected $comparisons = array('eq', 'neq', 'in', 'nin', 'contains');
+    protected $comparisons = array('eq', 'neq', 'in', 'nin', 'notIn', 'contains');
 
     /**
      * {@inheritdoc}

--- a/tests/Driver/Collection/CollectionDriverTest.php
+++ b/tests/Driver/Collection/CollectionDriverTest.php
@@ -351,7 +351,7 @@ class CollectionDriverTest extends \PHPUnit_Framework_TestCase
             $parameters = array(
                 $datasource->getName() => array(
                     DataSourceInterface::PARAMETER_FIELDS => array(
-                        'title_is_not' => ['title1', 'title2', 'title3']
+                        'title_is_not' => array('title1', 'title2', 'title3')
                     ),
                 ),
             );

--- a/tests/Driver/Collection/CollectionDriverTest.php
+++ b/tests/Driver/Collection/CollectionDriverTest.php
@@ -23,14 +23,17 @@ use FSi\Component\DataSource\Extension\Symfony;
 use FSi\Component\DataSource\Tests\Fixtures\Category;
 use FSi\Component\DataSource\Tests\Fixtures\Group;
 use FSi\Component\DataSource\Tests\Fixtures\News;
-use FSi\Component\DataSource\Tests\Fixtures\TestManagerRegistry;
-use Symfony\Component\Form;
 
 /**
  * Tests for Doctrine driver.
  */
 class CollectionDriverTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var EntityManager
+     */
+    private $em;
+
     /**
      * {@inheritdoc}
      */
@@ -86,7 +89,7 @@ class CollectionDriverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * General test for DataSource wtih DoctrineDriver in basic configuration.
+     * General test for DataSource wtih CollectionDriver in basic configuration.
      */
     public function testGeneral()
     {
@@ -339,6 +342,24 @@ class CollectionDriverTest extends \PHPUnit_Framework_TestCase
                 $this->assertEquals(false, $news->isActive());
                 break;
             }
+
+            // test 'notIn' comparison
+            $datasource->addField('title_is_not', 'text', 'notIn', array(
+                'field' => 'title',
+            ));
+
+            $parameters = array(
+                $datasource->getName() => array(
+                    DataSourceInterface::PARAMETER_FIELDS => array(
+                        'title_is_not' => ['title1', 'title2', 'title3']
+                    ),
+                ),
+            );
+
+            $datasource->bindParameters($parameters);
+            $view = $datasource->createView();
+            $result = $datasource->getResult();
+            $this->assertEquals(97, count($result));
         }
     }
 
@@ -390,7 +411,7 @@ class CollectionDriverTest extends \PHPUnit_Framework_TestCase
     /**
      * Return configured DoctrinFactory.
      *
-     * @return DoctrineFactory.
+     * @return CollectionFactory.
      */
     private function getCollectionFactory()
     {


### PR DESCRIPTION
Fixes #69