### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
     - php: 7.1
       env:
         - COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.2
     - php: 7.3
 
 before_script:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,7 +4,7 @@
          colors="true">
     <testsuites>
         <testsuite name="FSi Datasource Component Test Suite">
-            <directory>tests</directory>
+            <directory suffix="Test.php">tests</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/tests/DataSourceTest.php
+++ b/tests/DataSourceTest.php
@@ -42,10 +42,10 @@ class DataSourceTest extends TestCase
         $driver = $this->createDriverMock();
 
         $datasource = new DataSource($driver, 'name1');
-        $this->assertEquals($datasource->getName(), 'name1');
+        $this->assertEquals('name1', $datasource->getName());
 
         $datasource = new DataSource($driver, 'name2');
-        $this->assertEquals($datasource->getName(), 'name2');
+        $this->assertEquals('name2', $datasource->getName());
     }
 
     /**
@@ -263,7 +263,7 @@ class DataSourceTest extends TestCase
         $datasource->bindParameters($firstData);
         $datasource->bindParameters($secondData);
 
-        $result = $datasource->getResult();
+        $datasource->getResult();
     }
 
     /**
@@ -313,8 +313,8 @@ class DataSourceTest extends TestCase
         $datasource->setMaxResults($max);
         $datasource->setFirstResult($first);
 
-        $this->assertEquals($datasource->getMaxResults(), $max);
-        $this->assertEquals($datasource->getFirstResult(), $first);
+        $this->assertEquals($max, $datasource->getMaxResults());
+        $this->assertEquals($first, $datasource->getFirstResult());
     }
 
     /**
@@ -382,7 +382,7 @@ class DataSourceTest extends TestCase
 
         $datasource = new DataSource($this->createDriverMock());
         $datasource->setFactory($factory);
-        $this->assertEquals($datasource->getFactory(), $factory);
+        $this->assertEquals($factory, $datasource->getFactory());
     }
 
     /**

--- a/tests/DataSourceViewTest.php
+++ b/tests/DataSourceViewTest.php
@@ -244,7 +244,6 @@ class DataSourceViewTest extends TestCase
     private function createDatasourceMock()
     {
         return $this->getMockBuilder(DataSourceInterface::class)
-            ->setConstructorArgs([$this->createMock(DriverInterface::class)])
             ->getMock();
     }
 }

--- a/tests/Driver/Collection/CollectionDriverTest.php
+++ b/tests/Driver/Collection/CollectionDriverTest.php
@@ -38,7 +38,7 @@ class CollectionDriverTest extends TestCase
      */
     private $em;
 
-    public function setUp()
+    protected function setUp()
     {
         //The connection configuration.
         $dbParams = [
@@ -341,7 +341,7 @@ class CollectionDriverTest extends TestCase
         $driver->getCriteria();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         unset($this->em);
     }

--- a/tests/Driver/Doctrine/DBAL/DBALDriverTest.php
+++ b/tests/Driver/Doctrine/DBAL/DBALDriverTest.php
@@ -168,13 +168,13 @@ class DBALDriverTest extends TestBase
         $driver = new DBALDriver([new CoreExtension()], $this->connection, 'table');
         $this->assertTrue($driver->hasFieldType($type));
         $field = $driver->getFieldType($type);
-        $this->assertTrue($field instanceof FieldTypeInterface);
-        $this->assertTrue($field instanceof DBALFieldInterface);
+        $this->assertInstanceOf(FieldTypeInterface::class, $field);
+        $this->assertInstanceOf(DBALFieldInterface::class, $field);
 
         $this->assertTrue($field->getOptionsResolver()->isDefined('field'));
 
         $comparisons = $field->getAvailableComparisons();
-        $this->assertTrue(count($comparisons) > 0);
+        $this->assertGreaterThan(0, count($comparisons));
 
         foreach ($comparisons as $cmp) {
             $field = $driver->getFieldType($type);

--- a/tests/Driver/Doctrine/ORM/DoctrineDriverBasicTest.php
+++ b/tests/Driver/Doctrine/ORM/DoctrineDriverBasicTest.php
@@ -259,7 +259,7 @@ class DoctrineDriverBasicTest extends TestCase
         $this->assertTrue($field->getOptionsResolver()->isDefined('field'));
 
         $comparisons = $field->getAvailableComparisons();
-        $this->assertTrue(count($comparisons) > 0);
+        $this->assertGreaterThan(0, count($comparisons));
 
         foreach ($comparisons as $cmp) {
             $field = $driver->getFieldType($type);

--- a/tests/Driver/Doctrine/ORM/DoctrineDriverTest.php
+++ b/tests/Driver/Doctrine/ORM/DoctrineDriverTest.php
@@ -43,7 +43,7 @@ class DoctrineDriverTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp()
     {
         //The connection configuration.
         $dbParams = [
@@ -699,7 +699,7 @@ class DoctrineDriverTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function tearDown()
+    protected function tearDown()
     {
         unset($this->em);
     }

--- a/tests/Extension/Core/OrderingExtensionTest.php
+++ b/tests/Extension/Core/OrderingExtensionTest.php
@@ -30,10 +30,8 @@ class OrderingExtensionTest extends TestCase
     public function testStoringParameters()
     {
         $extension = new OrderingExtension();
-        $driver = $this->createMock(DriverInterface::class);
         /** @var MockObject|DataSourceInterface $datasource */
         $datasource = $this->getMockBuilder(DataSourceInterface::class)
-            ->setConstructorArgs([$driver])
             ->getMock();
         /** @var MockObject|FieldTypeInterface $field */
         $field = $this->createMock(FieldTypeInterface::class);

--- a/tests/Field/FieldViewTest.php
+++ b/tests/Field/FieldViewTest.php
@@ -100,6 +100,6 @@ class FieldViewTest extends TestCase
 
         $this->assertEquals(['option2' => null, 'option3' => 'value3', 'option4' => 'value4'], $view->getAttributes());
 
-        $this->assertEquals(null, $view->getAttribute('option5'));
+        $this->assertNull($view->getAttribute('option5'));
     }
 }


### PR DESCRIPTION
# Changed log
- Add `php-7.2` test on Travis CI build.
- Add `suffix` on `phpunit.xml.dist` to mark test classes.
- The `assertEquals` parameters are about `$expected, $actual`. Changing these argument positions.
- According to the [PHPUnit fixture reference](https://phpunit.de/manual/7.0/en/fixtures.html), the `setUp` and `tearDown` methods are `protected`, not `public`.
- Using `assertNull` to assert the `$expected` is same as `null`.
- Using `assertInstanceOf` to assert `$actual` is instance of specific class instance.
- Using the `assertGreaterThan` to assert that the `$expected` is greater than `$actual` value.

- The `DataSourceInterface::class` and `DriverInterface::class` don't have the `constructor` and they don't need to add the `setConstructorArgs` method.

This is about the PHPUnit problem.

Using the `--prefer-lowest` option to install required dependencies via composer, and the `PHPUnit 7.2.x` will be installed.

Without using the `--prefer-lowest` option to install required dependencies via composer, and the `PHPUnit 7.5.x` will be installed.

It will not throw `ReflectionException: Class Mocked_Class_Name does not have a constructor, so you cannot pass any constructor arguments` message when using the `PHPUnit 7.2.x` version.

And it will throw this exception message when using the `PHPUnit 7.5.x` version.